### PR TITLE
fixed compiler error when OLED SH1106 was selected and no panel (butt…

### DIFF
--- a/MK4duo/Configuration_Feature.h
+++ b/MK4duo/Configuration_Feature.h
@@ -335,7 +335,7 @@
  * the actual temperature is greater than IDLE_OOZING_MINTEMP.         *
  *                                                                     *
  * PS: Always remember to set your extruder target temperature to 0°C  *
- * before shoudown the printer if you enable this feature.             *
+ * before shutdown the printer if you enable this feature.             *
  *                                                                     *
  * Uncomment IDLE_OOZING_PREVENT to enable this feature                *
  *                                                                     *
@@ -1322,9 +1322,10 @@
 //#define LCD_I2C_VIKI
 
 //
-// SSD1306 OLED full graphics generic display
+// SSD1306 or SH1106 OLED full graphics generic display
 //
 //#define U8GLIB_SSD1306
+//#define U8GLIB_SH1106
 
 //
 // SAV OLEd LCD module support using either SSD1306 or SH1106 based LCD modules

--- a/MK4duo/src/boards/433.h
+++ b/MK4duo/src/boards/433.h
@@ -11,53 +11,66 @@
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
 #endif
 
+// X axis pins
 #define ORIG_X_STEP_PIN         54
 #define ORIG_X_DIR_PIN          55
 #define ORIG_X_ENABLE_PIN       38
 #define ORIG_X_MIN_PIN           3
 #define ORIG_X_MAX_PIN           2
 
+// Y axis pins
 #define ORIG_Y_STEP_PIN         60
 #define ORIG_Y_DIR_PIN          61
 #define ORIG_Y_ENABLE_PIN       56
 #define ORIG_Y_MIN_PIN          14
 #define ORIG_Y_MAX_PIN          15
 
+// Y2 axis pins
+#define Y2_STEP_PIN             36
+#define Y2_DIR_PIN              34
+#define Y2_ENABLE_PIN           30
+
+// Z axis pins
 #define ORIG_Z_STEP_PIN         46
 #define ORIG_Z_DIR_PIN          48
 #define ORIG_Z_ENABLE_PIN       62
 #define ORIG_Z_MIN_PIN          18
 #define ORIG_Z_MAX_PIN          19
 
-#define Y2_STEP_PIN             36
-#define Y2_DIR_PIN              34
-#define Y2_ENABLE_PIN           30
-
+// Z2 axis pins
 #define Z2_STEP_PIN             36
 #define Z2_DIR_PIN              34
 #define Z2_ENABLE_PIN           30
 
+// E0 axis pins
 #define ORIG_E0_STEP_PIN        26
 #define ORIG_E0_DIR_PIN         28
 #define ORIG_E0_ENABLE_PIN      24
 
+// E1 axis pins
 #define ORIG_E1_STEP_PIN        36
 #define ORIG_E1_DIR_PIN         34
 #define ORIG_E1_ENABLE_PIN      30
 
-#define ORIG_HEATER_0_PIN       10
+// heater pins
+#define ORIG_HEATER_0_PIN       10   // Hotend
 #define ORIG_HEATER_1_PIN       -1
 #define ORIG_HEATER_2_PIN       -1
-#define ORIG_HEATER_BED_PIN      8    // BED
+#define ORIG_HEATER_BED_PIN      8   // BED
 
+// temperature pins
 #define ORIG_TEMP_0_PIN          9   // ANALOG NUMBERING
 #define ORIG_TEMP_1_PIN         -1   // ANALOG NUMBERING
 #define ORIG_TEMP_2_PIN         -1   // ANALOG NUMBERING
 #define ORIG_TEMP_BED_PIN       10   // ANALOG NUMBERING
 
-#define ORIG_FAN_PIN             9
+#define ORIG_FAN_PIN             9   // Fan
 #define ORIG_PS_ON_PIN          12
 #define SDPOWER                 -1
 #define SDSS                    53
 #define LED_PIN                 13
 
+// OLED with SH1106 without encoder/buttons
+#if defined(U8GLIB_SSD1306) || defined(U8GLIB_SH1106)
+  #define BLEN_C 2
+#endif


### PR DESCRIPTION
Hi, 

First congratulations on well done job. I was configuring old version of Marlin previously (for Mega) and it is really not so well organized as here. 

I'm trying to compile MK4duo with Due and Ramps4Due and with OLED SH1106 (such as http://forums.reprap.org/read.php?13,499572).

Without display it compiles well, but when I try to add "#define U8GLIB_SH1106" in Configuration_Feature.h it fails, since I don't have any panel i.e. rotary encoder, button etc. 
I have added this define for someone else who would also try to use display with this chip.

My fix:
error occured in file ultralcd.h at line 95, where BLEN_C was not defined in 433.h
    #define EN_C (_BV(BLEN_C))
this is consequence of ifdef few lines above in same file, since ENC is not defined
    #if BUTTON_EXISTS(ENC)
      #define BLEN_C 2
    #endif

Better solution would probably be to prevent ULTIPANEL to be defined (?)

Best regards,
Marko


