### PR TITLE
Fix: MK4DuoBoards doesn't recognise end section token if it's not in a new line

### DIFF
--- a/MK4duo/src/boards/10.h
+++ b/MK4duo/src/boards/10.h
@@ -8,7 +8,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644__) && DISABLED(__AVR_ATmega644P__) && DISABLED(__AVR_ATmega1284P__)
   #error Oops!  Make sure you have 'Gen7' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/100.h
+++ b/MK4duo/src/boards/100.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644P__) && DISABLED(__AVR_ATmega1284P__)
   #error Oops!  Make sure you have 'Sanguino' or 'Anet' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/11.h
+++ b/MK4duo/src/boards/11.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644__) && DISABLED(__AVR_ATmega644P__) && DISABLED(__AVR_ATmega1284P__)
   #error Oops!  Make sure you have 'Gen7' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/12.h
+++ b/MK4duo/src/boards/12.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644__) && DISABLED(__AVR_ATmega644P__) && DISABLED(__AVR_ATmega1284P__)
   #error Oops!  Make sure you have 'Gen7' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/13.h
+++ b/MK4duo/src/boards/13.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644__) && DISABLED(__AVR_ATmega644P__) && DISABLED(__AVR_ATmega1284P__)
   #error Oops!  Make sure you have 'Gen7' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1400.h
+++ b/MK4duo/src/boards/1400.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Alligator 3D Printer Board' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1401.h
+++ b/MK4duo/src/boards/1401.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1403.h
+++ b/MK4duo/src/boards/1403.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1404.h
+++ b/MK4duo/src/boards/1404.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1411.h
+++ b/MK4duo/src/boards/1411.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1412.h
+++ b/MK4duo/src/boards/1412.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1413.h
+++ b/MK4duo/src/boards/1413.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1414.h
+++ b/MK4duo/src/boards/1414.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1433.h
+++ b/MK4duo/src/boards/1433.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1502.h
+++ b/MK4duo/src/boards/1502.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Alligator 3D Printer Board' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1503.h
+++ b/MK4duo/src/boards/1503.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Alligator 3D Printer Board' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/1705.h
+++ b/MK4duo/src/boards/1705.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(ARDUINO_ARCH_SAM)
   #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/2.h
+++ b/MK4duo/src/boards/2.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/20.h
+++ b/MK4duo/src/boards/20.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644__) && DISABLED(__AVR_ATmega644P__) && DISABLED(__AVR_ATmega1284P__)
   #error Oops!  Make sure you have 'Gen7' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/21.h
+++ b/MK4duo/src/boards/21.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/22.h
+++ b/MK4duo/src/boards/22.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644P__)
   #error Oops!  Make sure you have 'Sanguino' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/3.h
+++ b/MK4duo/src/boards/3.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/301.h
+++ b/MK4duo/src/boards/301.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/316.h
+++ b/MK4duo/src/boards/316.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/33.h
+++ b/MK4duo/src/boards/33.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/34.h
+++ b/MK4duo/src/boards/34.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/35.h
+++ b/MK4duo/src/boards/35.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/36.h
+++ b/MK4duo/src/boards/36.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/37.h
+++ b/MK4duo/src/boards/37.h
@@ -7,7 +7,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/39.h
+++ b/MK4duo/src/boards/39.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/4.h
+++ b/MK4duo/src/boards/4.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega328P__)
   #error Oops!  Make sure you have 'Arduino Duemilanove w/ ATMega328' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/40.h
+++ b/MK4duo/src/boards/40.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/41.h
+++ b/MK4duo/src/boards/41.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/47.h
+++ b/MK4duo/src/boards/47.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/49.h
+++ b/MK4duo/src/boards/49.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/5.h
+++ b/MK4duo/src/boards/5.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644__) && DISABLED(__AVR_ATmega644P__) && DISABLED(__AVR_ATmega1284P__)
   #error Oops!  Make sure you have 'Gen7' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/6.h
+++ b/MK4duo/src/boards/6.h
@@ -11,7 +11,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644P__) && DISABLED(__AVR_ATmega1284P__)
   #error Oops!  Make sure you have 'Sanguino' or 'Anet' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/67.h
+++ b/MK4duo/src/boards/67.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/68.h
+++ b/MK4duo/src/boards/68.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/7.h
+++ b/MK4duo/src/boards/7.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/70.h
+++ b/MK4duo/src/boards/70.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/701.h
+++ b/MK4duo/src/boards/701.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/702.h
+++ b/MK4duo/src/boards/702.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1281__)
   #error Oops! Make sure you have 'Minitronics ' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/703.h
+++ b/MK4duo/src/boards/703.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/71.h
+++ b/MK4duo/src/boards/71.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/72.h
+++ b/MK4duo/src/boards/72.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/77.h
+++ b/MK4duo/src/boards/77.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/78.h
+++ b/MK4duo/src/boards/78.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/79.h
+++ b/MK4duo/src/boards/79.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/8.h
+++ b/MK4duo/src/boards/8.h
@@ -12,7 +12,8 @@
 #endif
 #if ENABLED(AT90USBxx_TEENSYPP_ASSIGNMENTS)  // use Teensyduino Teensy++2.0 pin assignments instead of Marlin traditional.
   #error These Teensylu/Printrboard assignments depend on traditional Marlin assignments, not AT90USBxx_TEENSYPP_ASSIGNMENTS in fastio.h
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/80.h
+++ b/MK4duo/src/boards/80.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/9.h
+++ b/MK4duo/src/boards/9.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644P__) && DISABLED(__AVR_ATmega1284P__)
   #error Oops!  Make sure you have 'Sanguino' or 'Anet' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/90.h
+++ b/MK4duo/src/boards/90.h
@@ -32,7 +32,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644__)
   #error Oops!  Make sure you have 'SanguinoA' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/91.h
+++ b/MK4duo/src/boards/91.h
@@ -32,7 +32,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega644__)
   #error Oops!  Make sure you have 'SanguinoA' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 

--- a/MK4duo/src/boards/999.h
+++ b/MK4duo/src/boards/999.h
@@ -6,7 +6,8 @@
 //###CHIP
 #if DISABLED(__AVR_ATmega1280__) && DISABLED(__AVR_ATmega2560__)
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
-#endif//@@@
+#endif
+//@@@
 
 #define KNOWN_BOARD 1
 


### PR DESCRIPTION
Hi MagoKimbra!

If the "//@@@" token is not in a new line (at the start of the line), it will not be read by MK4DuoBoards.
The program will continue until it finds a //@@@ at the start of a line, ignoring what there is in between.

**## IMPORTANT: you should download the new version of MK4DuoBoards because I've made some fixes and performance improvements.**