### PR TITLE
Fixed eeprom.cpp, and STRINGIFY macro

### DIFF
--- a/MK4duo/src/eeprom/eeprom.cpp
+++ b/MK4duo/src/eeprom/eeprom.cpp
@@ -338,7 +338,7 @@ void EEPROM::Postprocess() {
     //
     // General Leveling
     //
-    #if HAS_LEVELING && ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+    #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       EEPROM_WRITE(bedlevel.z_fade_height);
     #endif
 
@@ -369,7 +369,7 @@ void EEPROM::Postprocess() {
     //
     // Bilinear Auto Bed Leveling
     //
-    #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
       static_assert(
         sizeof(bedlevel.z_values) == GRID_MAX_POINTS * sizeof(bedlevel.z_values[0][0]),
         "Bilinear Z array is the wrong size."
@@ -670,7 +670,7 @@ void EEPROM::Postprocess() {
       //
       // General Leveling
       //
-      #if HAS_LEVELING && ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+      #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
         EEPROM_READ(bedlevel.z_fade_height);
       #endif
 
@@ -707,7 +707,7 @@ void EEPROM::Postprocess() {
       //
       // Bilinear Auto Bed Leveling
       //
-      #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_BILINEAR)
+      #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
         uint8_t grid_max_x, grid_max_y;
         EEPROM_READ(grid_max_x);              // 1 byte
         EEPROM_READ(grid_max_y);              // 1 byte
@@ -1001,7 +1001,7 @@ void EEPROM::Factory_Settings() {
   mechanics.max_jerk[Y_AXIS] = DEFAULT_YJERK;
   mechanics.max_jerk[Z_AXIS] = DEFAULT_ZJERK;
 
-  #if HAS_LEVELING && ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+  #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
     bedlevel.z_fade_height = 0.0;
   #endif
 

--- a/MK4duo/src/eeprom/eeprom.cpp
+++ b/MK4duo/src/eeprom/eeprom.cpp
@@ -195,7 +195,7 @@ void EEPROM::Postprocess() {
     bedlevel.set_z_fade_height(bedlevel.z_fade_height);
   #endif
 
-  #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_BILINEAR)
     bedlevel.refresh_bed_level();
   #endif
 }
@@ -338,7 +338,7 @@ void EEPROM::Postprocess() {
     //
     // General Leveling
     //
-    #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+    #if HAS_LEVELING && ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       EEPROM_WRITE(bedlevel.z_fade_height);
     #endif
 
@@ -369,7 +369,7 @@ void EEPROM::Postprocess() {
     //
     // Bilinear Auto Bed Leveling
     //
-    #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_BILINEAR)
       static_assert(
         sizeof(bedlevel.z_values) == GRID_MAX_POINTS * sizeof(bedlevel.z_values[0][0]),
         "Bilinear Z array is the wrong size."
@@ -670,7 +670,7 @@ void EEPROM::Postprocess() {
       //
       // General Leveling
       //
-      #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+      #if HAS_LEVELING && ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
         EEPROM_READ(bedlevel.z_fade_height);
       #endif
 
@@ -707,7 +707,7 @@ void EEPROM::Postprocess() {
       //
       // Bilinear Auto Bed Leveling
       //
-      #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+      #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_BILINEAR)
         uint8_t grid_max_x, grid_max_y;
         EEPROM_READ(grid_max_x);              // 1 byte
         EEPROM_READ(grid_max_y);              // 1 byte
@@ -1001,7 +1001,7 @@ void EEPROM::Factory_Settings() {
   mechanics.max_jerk[Y_AXIS] = DEFAULT_YJERK;
   mechanics.max_jerk[Z_AXIS] = DEFAULT_ZJERK;
 
-  #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+  #if HAS_LEVELING && ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
     bedlevel.z_fade_height = 0.0;
   #endif
 

--- a/MK4duo/src/eeprom/eeprom.cpp
+++ b/MK4duo/src/eeprom/eeprom.cpp
@@ -191,11 +191,11 @@ void EEPROM::Postprocess() {
     LOOP_XYZ(i) endstops.update_software_endstops((AxisEnum)i);
   #endif
 
-  #if HAS_LEVELING && ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+  #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
     bedlevel.set_z_fade_height(bedlevel.z_fade_height);
   #endif
 
-  #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
     bedlevel.refresh_bed_level();
   #endif
 }

--- a/MK4duo/src/macros.h
+++ b/MK4duo/src/macros.h
@@ -68,7 +68,8 @@
 #define UNUSED(x) (void) (x)
 
 // Macros to make a string from a macro
-#define STRINGIFY(M) #M
+#define _STRINGIFY_(M) #M
+#define STRINGIFY(M) _STRINGIFY_(M)
 
 // Macros for communication
 #define FSTRINGVALUE(var,value) const char var[] PROGMEM = value;

--- a/MK4duo/src/macros.h
+++ b/MK4duo/src/macros.h
@@ -68,8 +68,8 @@
 #define UNUSED(x) (void) (x)
 
 // Macros to make a string from a macro
-#define _STRINGIFY_(M) #M
-#define STRINGIFY(M) _STRINGIFY_(M)
+#define STRINGIFY_(M) #M           //DO NOT USE this macro!
+#define STRINGIFY(M) STRINGIFY_(M) //This macro is more safe because it also expands the macro M !!!
 
 // Macros for communication
 #define FSTRINGVALUE(var,value) const char var[] PROGMEM = value;


### PR DESCRIPTION
Fixed an issue in eeprom.cpp while compiling with EEPROM enabled and HAS_BED_LEVELING==false